### PR TITLE
Fix build errors after source code moved

### DIFF
--- a/Chirp.sln
+++ b/Chirp.sln
@@ -16,10 +16,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C921D053-D66C-72DB-0ABE-BD53FAB2EB6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C921D053-D66C-72DB-0ABE-BD53FAB2EB6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C921D053-D66C-72DB-0ABE-BD53FAB2EB6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C921D053-D66C-72DB-0ABE-BD53FAB2EB6F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F79E6CBF-2FCC-4F7E-A0AC-EEDF5A287553}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F79E6CBF-2FCC-4F7E-A0AC-EEDF5A287553}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F79E6CBF-2FCC-4F7E-A0AC-EEDF5A287553}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/Chirp.csproj
+++ b/src/Chirp.csproj
@@ -12,4 +12,9 @@
     <PackageReference Include="docopt.net" Version="0.8.1" />
   </ItemGroup>
 
+  <!-- To fix duplicate errors CS0579. -->
+  <PropertyGroup>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes build errors by avoid generating assembly info. But maybe not good? Idk