### PR TITLE
Fix github build action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,9 @@ name: .NET
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
Switch from $default-branch to main inside the github build action yml

$default-branch was not a real variable inside github actions, this should fix CI on commit to main