### PR TITLE
Encode name as URL in navigation bar

### DIFF
--- a/src/Chirp.Web/Pages/Shared/_LoginPartial.cshtml
+++ b/src/Chirp.Web/Pages/Shared/_LoginPartial.cshtml
@@ -1,5 +1,4 @@
 @using Microsoft.AspNetCore.Identity
-@using System.Web
 @inject SignInManager<Author> SignInManager
 @inject UserManager<Author> UserManager
 
@@ -7,7 +6,7 @@
     @if (SignInManager.IsSignedIn(User))
     {
         string name = (await UserManager.GetUserAsync(User))!.Name;
-        string nameUrl = HttpUtility.UrlEncode(name);
+        string nameUrl = Uri.EscapeDataString(name);
         <div>
             <a href="/@(nameUrl)">my timeline</a> |
             <a href="/">public timeline</a> |


### PR DESCRIPTION
Small fix that encodes the link to "my timeline" as a URL. Allows users with name like "?page=2" to use the site normally.
- Previously, their URL would be `/?page=2` which redirects to page 2 of the public timeline. Not good
- With the fix, their URL is `/%3fpage%3d2` which is correctly showing the timeline of user named "?page=2". Good

<img width="905" height="459" alt="image" src="https://github.com/user-attachments/assets/53a0aa9b-f059-4335-8efc-f6ffe3aeafdc" />

Edit: There is a lot of different URL encoders in .NET which all do it slightly differently, see [this stackoverflow](https://stackoverflow.com/a/11236038). I have switched to Uri.EscapeDataString since it both handles names with spaces and names like ?page=2.