### PR TITLE
Fail test when Razor process exits

### DIFF
--- a/test/Razor.Tests/TestUtils.cs
+++ b/test/Razor.Tests/TestUtils.cs
@@ -18,6 +18,7 @@ public static class TestUtils
         process.StartInfo.Arguments = $"run --project ../../../../../{RazorPath}";
         process.StartInfo.UseShellExecute = false;
         process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
         process.Start();
 
         var baseURL = "http://localhost:5273";
@@ -34,6 +35,7 @@ public static class TestUtils
             }
             catch (Exception)
             {
+                if (process.HasExited) Assert.Fail($"Razor process exited. {process.StandardError.ReadToEnd()}");
                 Thread.Sleep(10000);
             }
         }


### PR DESCRIPTION
When Razor process fails during end2endtest, the test does nothing and eventually fails after a very long time. This shows an error message early indicating the error in the process.