### PR TITLE
Add github action for discord notifications on pull request

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -15,4 +15,4 @@ jobs:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       uses: Ilshidur/action-discord@0.4.0
       with:
-        args: 'Pull Request ready for review: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.number }}'
+        args: '@everyone Pull Request ready for review: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.number }}'


### PR DESCRIPTION
As mentioned in discussion #117, this can send a ping to our Discord group when a pull request is opened.

Requires us to register a webhook in Discord and add it to the GitHub secrets, under the name `DISCORD_WEBHOOK`.