### PR TITLE
Sign out if the user doesn't exist in the database

### DIFF
--- a/src/Chirp.Web/Pages/Shared/_SubmitMessage.cshtml
+++ b/src/Chirp.Web/Pages/Shared/_SubmitMessage.cshtml
@@ -11,9 +11,9 @@
 @if (SignInManager.IsSignedIn(User))
 {
     Author? author = await UserManager.GetUserAsync(User);
-    string authorName = author!.Name;
-    if (author != null && authorName != null)
+    if (author != null && author.Name != null)
     {
+        string authorName = author!.Name;
         <div class="cheepbox">
             <h3>What's on your mind @authorName?</h3>
             <form method="post">
@@ -24,8 +24,6 @@
     }
     else
     {
-        <div>
-            <p>Account or name not found!</p> @*this will most likely never happen*@
-        </div>
+        await SignInManager.SignOutAsync();
     }
 }


### PR DESCRIPTION
Before: If you were logged in and in someone's timeline, shutdown the server, deleted the database, ran the server and refreshed the page, you would get an error. This happened because you technically still had a valid session, but you didn't exist in the database.

Now: If you repeat the steps above, you'll now be logged out.